### PR TITLE
Load Supabase config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ AIrWAVE is a comprehensive platform that streamlines the creation, management, a
    NEXT_PUBLIC_API_URL=your_api_url
    OPENAI_API_KEY=your_openai_key
    ELEVENLABS_API_KEY=your_elevenlabs_key
+   SUPABASE_URL=your_supabase_url
+   SUPABASE_ANON_KEY=your_supabase_anon_key
+   SUPABASE_SERVICE_KEY=your_supabase_service_key
    ```
+
+   `SUPABASE_SERVICE_KEY` is only required when running maintenance scripts such as `create-test-users.js`.
 
 4. Start the development server:
    ```

--- a/scripts/create-test-users.js
+++ b/scripts/create-test-users.js
@@ -8,8 +8,13 @@ const { createClient } = require('@supabase/supabase-js');
 require('dotenv').config();
 
 // Supabase configuration
-const supabaseUrl = 'https://fdsjlutmfaatslznjxiv.supabase.co';
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkc2psdXRtZmFhdHNsem5qeGl2Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0NzU3NDIxNCwiZXhwIjoyMDYzMTUwMjE0fQ.ZpffWj4u0E9dt_XPmoPZKENvqMI5AwuMRB6VCOBJ0K4';
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_KEY environment variables are required');
+  process.exit(1);
+}
 
 // Initialize Supabase client with service role key
 const supabase = createClient(supabaseUrl, supabaseServiceKey);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://fdsjlutmfaatslznjxiv.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkc2psdXRtZmFhdHNsem5qeGl2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc1NzQyMTQsImV4cCI6MjA2MzE1MDIxNH0.wO2DjC0Y2lRQj9lzMJ-frqlMXuC-r5TM-wwmRQXN5Fg';
+const supabaseUrl = process.env.SUPABASE_URL || '';
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || '';
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be provided');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 


### PR DESCRIPTION
## Summary
- read Supabase credentials from environment variables in `src/lib/supabase.ts`
- make `scripts/create-test-users.js` require env vars instead of using hard-coded values
- document `SUPABASE_URL`, `SUPABASE_ANON_KEY` and `SUPABASE_SERVICE_KEY` in README

## Testing
- `npm test -- --passWithNoTests`
