### PR TITLE
Fix Netlify deployment error: Remove displayName from ErrorBoundary class

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -131,8 +131,6 @@ class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-ErrorBoundary.displayName = 'ErrorBoundary';
-
 export default ErrorBoundary;
 
 // Hook for functional components to trigger error boundaries


### PR DESCRIPTION
## Summary

This PR fixes the Netlify deployment error caused by a TypeScript compilation issue.

## Problem

The build was failing with the following error:
```
Type error: Property 'displayName' does not exist on type 'typeof ErrorBoundary'.
```

## Solution

Removed the `displayName` assignment from the ErrorBoundary class component. In TypeScript, the `displayName` property is not part of the type definition for class components, and it's not necessary since class components already have their name available through the class name itself.

The `displayName` property is kept for the functional component wrapper (`withErrorBoundary`) where it's properly supported.

## Testing

- TypeScript compilation now passes
- ErrorBoundary functionality remains unchanged
- The component name is still available for React DevTools through the class name

This fix will allow the Netlify deployment to proceed successfully.