### PR TITLE
Disable demo mode for production deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 [build.environment]
   NODE_VERSION = "18"
   NPM_VERSION = "10"
-  NEXT_PUBLIC_DEMO_MODE = "true"
+  NEXT_PUBLIC_DEMO_MODE = "false"
 
 [[headers]]
   for = "/api/*"


### PR DESCRIPTION
## Disable Demo Mode for Production

This PR changes the Netlify configuration to enable production mode with real Supabase integration.

### Changes
- Set `NEXT_PUBLIC_DEMO_MODE = "false"` in `netlify.toml`

### Why This Is Important
The build logs showed the app was running in demo mode:
```
🎮 Demo Mode: Enabled
```

This means the app would be using mock data instead of connecting to your real Supabase database.

### After This Change
- The app will connect to your Supabase instance
- Authentication will use real Supabase Auth
- All data operations will use your Supabase database
- Features like Creatomate video rendering will be active

⚠️ **Important**: Make sure your Supabase database is set up with the migration scripts before merging this!