### PR TITLE
Fix: Netlify 404 error - Remove incorrect publish directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
 [build]
   command = "npm run build"
-  publish = ".next"
   
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## 🐛 Fix for Netlify 404 Error

This PR fixes the 404 error you're experiencing on your deployed Netlify site.

### Problem
The `netlify.toml` file had `publish = ".next"` which tells Netlify to serve files from the `.next` build directory. However, when using the `@netlify/plugin-nextjs` plugin, this causes issues because the plugin handles the build output automatically and expects a different directory structure.

### Solution
Removed the `publish = ".next"` line from `netlify.toml`. The `@netlify/plugin-nextjs` plugin will automatically handle serving the correct files.

### Changes Made
- Removed `publish = ".next"` from the `[build]` section in `netlify.toml`

### Next Steps
1. Merge this PR
2. Netlify will automatically trigger a new deployment
3. Your site should now load correctly without the 404 error

### Additional Notes
The `@netlify/plugin-nextjs` plugin handles:
- Static file serving
- API routes
- Dynamic routes
- ISR (Incremental Static Regeneration)
- All Next.js specific features

No other configuration changes are needed!